### PR TITLE
make urlpatterns work with django 1.10

### DIFF
--- a/documentation/urls.py
+++ b/documentation/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns(
-    'documentation.views',
+from .views import documentation
 
-    url(r'^$', 'documentation', 'index.html'),
-    url(r'^(?P<path>.*)$', 'documentation', name="path"),
-)
+urlpatterns = [
+    url(r'^$', documentation, 'index.html'),
+    url(r'^(?P<path>.*)$', documentation, name="path"),
+]


### PR DESCRIPTION
django.conf.urls.patterns() has been removed in 1.10 (deprecated since 1.8)